### PR TITLE
add tagname to gh.env in new job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,6 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      
+      - name: Set Tag Name
+        run: echo "TAGNAME=$(echo ${{ github.ref }} | cut -d '/' -f3)" >> $GITHUB_ENV 
 
       - name: Trigger repository dispatch event
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
Sorry for the mistake,
but I didn't knew that env vars added to GITHUB_ENV in a jobs aren't accessible across other jobs.