### PR TITLE
workflow: Update softprops/action-gh-release

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,7 +42,7 @@ jobs:
           path: /home/builder/materialgram/fakeroot/materialgram-${{ env.TAGNAME }}.tar.gz
 
       - name: Upload artifact to Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: ${{ env.TAGNAME }}

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -46,7 +46,7 @@ jobs:
           path: /home/builder/materialgram/fakeroot/materialgram-${{ github.event.inputs.tagname }}.tar.gz
 
       - name: Upload artifact to Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ github.event.inputs.tagname }}
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
addresses warning: "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: softprops/action-gh-release@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20."