### PR TITLE
[BUILD] Fix docker permission err for linux build workflow 

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,6 +47,7 @@ jobs:
           fi
 
           docker run --rm \
+          -u $(id -u):$(id -g) \
           -v $PWD:/usr/src/tdesktop \
           -e CONFIG=Release \
           materialgram:build \


### PR DESCRIPTION
The `-u $(id -u):$(id -g)` flag sets the container's user and group to match the host's `UID` and `GID`, resolving permission issues when writing to a mounted volume. Which ensures the container has write access to the host directory `($PWD)`.